### PR TITLE
Add Joung-Cheatham parameters for tip3p-fb

### DIFF
--- a/forcefields/jc_tip3p-fb.xml
+++ b/forcefields/jc_tip3p-fb.xml
@@ -1,0 +1,31 @@
+<ForceField>
+ <!--
+ Ion Parameters to be used with TIP3P-FB from Joung and Cheatham, DOI: 10.1021/jp8001614
+ -->
+ <AtomTypes>
+  <Type name="jc_001" class="Li+" element="Li" mass="6.94100" def="Li" desc="lithium ion"/>
+  <Type name="jc_002" class="Na+" element="Na" mass="22.98977" def="Na" desc="sodium ion"/>
+  <Type name="jc_003" class="K+" element="K" mass="39.0983" def="K" desc="potassium ion"/>
+  <Type name="jc_004" class="Rb+" element="Rb" mass="85.4678" def="Rb" desc="Rubidium ion"/>
+  <Type name="jc_005" class="Cs+" element="Cs" mass="132.9055" def="Cs" desc="cesium ion"/>
+  <Type name="jc_006" class="F-" element="F" mass="18.9984" def="F" desc="Fluorine ion"/>
+  <Type name="jc_007" class="Cl-" element="Cl" mass="35.4530" def="Cl" desc="chlorine ion"/>
+  <Type name="jc_008" class="Br-" element="Br" mass="79.904" def="Br" desc="Bromine ion"/>
+  <Type name="jc_009" class="I-" element="I" mass="126.9045" def="I" desc="Iodine ion"/>
+  <Type name="jc_010" class="Ca+2" element="Ca" mass="40.08" def="Ca" desc="Calcium ion"/>
+  <Type name="jc_011" class="Mg+2" element="Mg" mass="24.305" def="Mg" desc="Magnesium ion"/>
+ </AtomTypes>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+  <Atom type="jc_001" charge="1.000" sigma="0.1826" epsilon="0.117108486"/>
+  <Atom type="jc_002" charge="1.000" sigma="0.2439" epsilon="0.365846031"/>
+  <Atom type="jc_003" charge="1.000" sigma="0.3038" epsilon="0.810369254"/>
+  <Atom type="jc_004" charge="1.000" sigma="0.3230" epsilon="1.37160683"/>
+  <Atom type="jc_005" charge="1.000" sigma="0.3521" epsilon="1.70096085"/>
+  <Atom type="jc_006" charge="-1.000" sigma="0.4104" epsilon="0.014074976"/>
+  <Atom type="jc_007" charge="-1.000" sigma="0.4478" epsilon="0.148912744"/>
+  <Atom type="jc_008" charge="-1.000" sigma="0.4647" epsilon="0.24541494"/>
+  <Atom type="jc_009" charge="-1.000" sigma="0.5096" epsilon="0.2246038414"/>
+  <Atom type="jc_010" charge="2.000" sigma="0.29381839724268394" epsilon="0.4432056808"/>
+  <Atom type="jc_011" charge="2.000" sigma="0.2423244513341723" epsilon="0.042686716080000006"/>
+ </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
Not sure if the JC parameters are any different for TIP3P vs TIP3P-Fb.  The divalent cations are adapted from: https://github.com/openmm/openmm/blob/master/wrappers/python/simtk/openmm/app/data/amber14/tip3pfb.xml

Testing these parameters now for `CaCl_2` and `MgCl_2`.